### PR TITLE
Add launch template keypair and NAT Gateway ID vars to alternat TF module

### DIFF
--- a/functions/replace-route/app.py
+++ b/functions/replace-route/app.py
@@ -67,6 +67,9 @@ def get_vpc_id(route_table):
 
 
 def get_nat_gateway_id(vpc_id, subnet_id):
+    nat_gateway_id = os.getenv("NAT_GATEWAY_ID")
+    if nat_gateway_id:
+        return nat_gateway_id
     try:
         nat_gateways = ec2_client.describe_nat_gateways(
             Filters=[

--- a/modules/terraform-aws-alternat/lambda.tf
+++ b/modules/terraform-aws-alternat/lambda.tf
@@ -147,6 +147,7 @@ resource "aws_lambda_function" "alternat_connectivity_tester" {
       ROUTE_TABLE_IDS_CSV = join(",", each.value.route_table_ids),
       PUBLIC_SUBNET_ID    = each.value.public_subnet_id
       CHECK_URLS          = join(",", var.connectivity_test_check_urls)
+      NAT_GATEWAY_ID      = each.value.nat_gateway_id
     }, var.lambda_environment_variables)
   }
 

--- a/modules/terraform-aws-alternat/main.tf
+++ b/modules/terraform-aws-alternat/main.tf
@@ -225,6 +225,8 @@ resource "aws_launch_template" "nat_instance_template" {
 
   instance_type = var.nat_instance_type
 
+  key_name = var.nat_instance_launch_template_keypair
+
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -236,3 +236,9 @@ variable "lambda_function_architectures" {
   type        = list(string)
   default     = ["x86_64"]
 }
+
+variable "nat_instance_launch_template_keypair" {
+  description = "key_pair name for NAT Instance launch template"
+  type        = string
+  default     = null
+}

--- a/modules/terraform-aws-alternat/variables.tf
+++ b/modules/terraform-aws-alternat/variables.tf
@@ -174,6 +174,7 @@ variable "vpc_az_maps" {
     private_subnet_ids = list(string)
     public_subnet_id   = string
     route_table_ids    = list(string)
+    nat_gateway_id     = optional(string)
   }))
 }
 


### PR DESCRIPTION
Configure two additional variables in Alternat terraform module:
- launch template keypair 
- NAT Gateway ID (standby NAT GW)

